### PR TITLE
Verificaciones antes de guardar la estación

### DIFF
--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/dao/EstacionDAO.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/dao/EstacionDAO.java
@@ -3,6 +3,7 @@ package mx.unam.fi.tesis.movilidad.dao;
 import java.util.List;
 
 import mx.unam.fi.tesis.movilidad.web.model.Estacion;
+import mx.unam.fi.tesis.movilidad.web.model.Ruta;
 
 /**
  * Declaración de las funciones para las estaciones
@@ -20,5 +21,12 @@ public interface EstacionDAO {
    * @param estacion Información de la estación a guardar.
    */
   void guardarEstacion(Estacion estacion);
+
+  /**
+   * Función que verifica si hay rutas cercas de la estación a guardar.
+   * @param estacion coordenadas de la estación
+   * @return Lista de rutas cercanas
+   */
+  List<Ruta> verificarRuta(Estacion estacion);
 
 }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/dao/EstacionDAOImpl.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/dao/EstacionDAOImpl.java
@@ -1,15 +1,22 @@
 package mx.unam.fi.tesis.movilidad.dao;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.PreparedStatementCreator;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import mx.unam.fi.tesis.movilidad.web.model.Estacion;
+import mx.unam.fi.tesis.movilidad.web.model.Ruta;
 
 /**
  * Definición de las funciones para las estaciones y que obtendran información
@@ -23,6 +30,12 @@ public class EstacionDAOImpl extends GenericJdbcDAO implements EstacionDAO {
     "SELECT nombre, estacion_id FROM estacion";
   private static final String insert_estacion_sql =
     "INSERT INTO estacion (nombre,geo) VALUES(?,ST_GeomFromText(?))";
+  private static final String verifica_estacion_ruta =
+    "SELECT q1.ruta_id,q1.ruta_nombre FROM (SELECT ruta_id, ruta_nombre, "
+      + "st_intersects(geo,ST_Buffer(ST_GeomFromText('?'),0.002)) "
+      + "as interseccion from ruta) q1 where interseccion = true";
+  private static final String insert_estacion_ruta_sql =
+    "INSERT INTO estacion_ruta(estacion_id,ruta_id) VALUES(?,?)";
 
   @Override
   public List<Estacion> getListado() {
@@ -41,9 +54,60 @@ public class EstacionDAOImpl extends GenericJdbcDAO implements EstacionDAO {
 
   @Override
   public void guardarEstacion(Estacion estacion) {
-    int regActualizados = getJdbcTemplate().update(insert_estacion_sql,
-      estacion.getNombre(), estacion.getGeo().toString());
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    int regActualizados = getJdbcTemplate().update(new PreparedStatementCreator() {
+      @Override
+      public PreparedStatement createPreparedStatement(Connection connection)
+        throws SQLException {
+        PreparedStatement ps = connection.prepareStatement(insert_estacion_sql,
+          new String[] { "estacion_id" });
+        ps.setString(1, estacion.getNombre());
+        ps.setString(2, estacion.getGeo().toString());
+        return ps;
+      }
+    }, keyHolder
+
+    );
+    guardarEstacionRuta(keyHolder.getKey().intValue(), estacion.getEstacionRuta());
     checkRowUpdated(1, regActualizados);
+  }
+
+  @Override
+  public List<Ruta> verificarRuta(Estacion estacion) {
+    String verifica_sql =
+      verifica_estacion_ruta.replace("?", estacion.getGeo().toString());
+
+    List<Ruta> listRuta = getJdbcTemplate().query(verifica_sql, new RowMapper<Ruta>() {
+      @Override
+      public Ruta mapRow(ResultSet rs, int rowNum) throws SQLException {
+        Ruta ruta = new Ruta();
+        ruta.setRutaId(rs.getLong(1));
+        ruta.setRutaNombre(rs.getString(2));
+        return ruta;
+      }
+    });
+    return listRuta;
+  }
+
+  /**
+   * Función que guarda en la tabla estacion_ruta
+   * @param estacionId identificador de la estación que fue guardada.
+   * @param rutaId rutas a las que fue asociada la estación
+   */
+  public void guardarEstacionRuta(int estacionId, int[] rutaId) {
+    getJdbcTemplate().batchUpdate(insert_estacion_ruta_sql,
+      new BatchPreparedStatementSetter() {
+        @Override
+        public void setValues(PreparedStatement ps, int i) throws SQLException {
+          ps.setLong(1, estacionId);
+          ps.setLong(2, rutaId[i]);
+        }
+
+        @Override
+        public int getBatchSize() {
+          return rutaId.length;
+        }
+      });
   }
 
 }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/controller/RestEstacionController.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/controller/RestEstacionController.java
@@ -1,5 +1,7 @@
 package mx.unam.fi.tesis.movilidad.web.controller;
 
+import java.util.List;
+
 import javax.annotation.Resource;
 
 import org.slf4j.Logger;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import mx.unam.fi.tesis.movilidad.web.model.Estacion;
 import mx.unam.fi.tesis.movilidad.web.model.Mensaje;
+import mx.unam.fi.tesis.movilidad.web.model.Ruta;
 import mx.unam.fi.tesis.movilidad.web.service.EstacionService;
 
 @RestController
@@ -32,5 +35,16 @@ public class RestEstacionController extends GenericController {
     respuesta = generarMensaje("true", "Correcto!",
       "La estación se ha guardado correctamente.", "success");
     return respuesta;
+  }
+
+  /**
+   * Método que verifica si hay rutas cercanas a la estación.
+   * @param estacion
+   * @return
+   */
+  @RequestMapping(value = "verificarRuta", method = RequestMethod.POST)
+  public List<Ruta> verificarRuta(@RequestBody Estacion estacion) {
+    List<Ruta> ruta = estacionService.verificarRuta(estacion);
+    return ruta;
   }
 }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/model/Estacion.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/model/Estacion.java
@@ -14,6 +14,7 @@ public class Estacion implements Serializable {
   private String nombre;
   private double x;
   private double y;
+  private int[] estacionRuta;
 
   /**
    * Get para el atributo estacion_id
@@ -85,6 +86,23 @@ public class Estacion implements Serializable {
    */
   public Point getGeo() {
     return new Point(this.x, this.y);
+  }
+
+  /**
+   * Arreglo de rutas asociadas a la estación.
+   * @param estacionRuta
+   */
+  public void setEstacionRuta(int[] estacionRuta) {
+    this.estacionRuta = new int[estacionRuta.length];
+    System.arraycopy(estacionRuta, 0, this.estacionRuta, 0, estacionRuta.length);
+  }
+
+  /**
+   * get para las rutas asociadas a una estación.
+   * @return
+   */
+  public int[] getEstacionRuta() {
+    return this.estacionRuta;
   }
 
 }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/model/Ruta.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/model/Ruta.java
@@ -18,27 +18,54 @@ public class Ruta implements Serializable {
   @JsonIgnore
   private LineString geo;
 
+  /**
+   * get para el atributo ruta_id
+   * @return
+   */
   public Long getRutaId() {
     return rutaId;
   }
 
+  /**
+   * set para el atriburo ruta_id
+   * @param ruta_id
+   */
   public void setRutaId(Long ruta_id) {
     this.rutaId = ruta_id;
   }
 
+  /**
+   * get para el atributo ruta_nombre
+   * @return
+   */
   public String getRutaNombre() {
     return rutaNombre;
   }
 
+  /**
+   * set para el atributo ruta_nombre
+   * @param ruta_nombre
+   */
   public void setRutaNombre(String ruta_nombre) {
     this.rutaNombre = ruta_nombre;
   }
 
+  /**
+   * get para la geometría
+   * @return
+   */
   public Point[] getGeo() {
+    if (geo == null) {
+      return null;
+    }
     Point[] puntos = geo.getPoints();
     return puntos;
   }
 
+  /**
+   * set para la geometría
+   * @param coordenadas
+   */
   public void setGeo(double[] coordenadas) {
     Point[] puntos = new Point[coordenadas.length - 1];
     int indice = 0;
@@ -51,10 +78,18 @@ public class Ruta implements Serializable {
     }
   }
 
+  /**
+   * get para la cadena de la geometría
+   * @return
+   */
   public String getGeometria() {
     return geometria;
   }
 
+  /**
+   * set para le cadena de la geometría
+   * @param geometria
+   */
   public void setGeometria(String geometria) {
     this.geometria = geometria;
   }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/service/EstacionService.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/service/EstacionService.java
@@ -3,6 +3,7 @@ package mx.unam.fi.tesis.movilidad.web.service;
 import java.util.List;
 
 import mx.unam.fi.tesis.movilidad.web.model.Estacion;
+import mx.unam.fi.tesis.movilidad.web.model.Ruta;
 
 /**
  * Definición de las funciones para el servicio de estaciones.
@@ -20,4 +21,11 @@ public interface EstacionService {
    * @param estacion Información de la estación introducida en el formulario.
    */
   void guardarEstacion(Estacion estacion);
+
+  /**
+   * Servicio para verificar las rutas cercanas a una estación
+   * @param estacion
+   * @return
+   */
+  List<Ruta> verificarRuta(Estacion estacion);
 }

--- a/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/service/EstacionServiceImpl.java
+++ b/movilidad-unam-web/src/main/java/mx/unam/fi/tesis/movilidad/web/service/EstacionServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import mx.unam.fi.tesis.movilidad.dao.EstacionDAO;
 import mx.unam.fi.tesis.movilidad.web.controller.EstacionController;
 import mx.unam.fi.tesis.movilidad.web.model.Estacion;
+import mx.unam.fi.tesis.movilidad.web.model.Ruta;
 
 /**
  * Declaracion de las funciones para el servicio de las estaciones.
@@ -30,5 +31,10 @@ public class EstacionServiceImpl implements EstacionService {
   @Override
   public void guardarEstacion(Estacion estacion) {
     estacionDao.guardarEstacion(estacion);
+  }
+
+  @Override
+  public List<Ruta> verificarRuta(Estacion estacion) {
+    return estacionDao.verificarRuta(estacion);
   }
 }

--- a/movilidad-unam-web/src/main/webapp/WEB-INF/resources/js/estacion/agregar.js
+++ b/movilidad-unam-web/src/main/webapp/WEB-INF/resources/js/estacion/agregar.js
@@ -10,15 +10,33 @@ $( document ).ready(function() {
   });
 	
   $("#modalAgregarEstacion #modalEnviar").on('click',function(){
-    var nombre = $("#nombreEstacion").val();
-    var datos = {"nombre":nombre,"x": marker.getPosition().lat(), 
-    		     "y":marker.getPosition().lng()};
-    guardar("/RestEstacion/guardar",datos,"#modalAgregarEstacion","/estacion/listar",
-    		"#estacion-listado");
+    var checkSeleccionados = $("input[type=checkbox]:checked");
+    if(checkSeleccionados.length > 0){
+      var rutas = [];
+      rutas = relacionRutaEstacion(checkSeleccionados);
+      var nombre = $("#nombreEstacion").val();
+      var datos = {"nombre":nombre,"x": marker.getPosition().lat(), 
+                   "y":marker.getPosition().lng(),"estacionRuta":rutas};
+      guardar("/RestEstacion/guardar",datos,"#modalAgregarEstacion","/estacion/listar",
+                "#estacion-listado");
+    }else{
+      pnotify("¡Ciudado!","Se debe seleccionar por lo menos una ruta cercana a la " +
+      		"estación.","warning");
+    }
   });	
 });
 
 function initMap() {
+  var CU = new google.maps.Polygon({
+    paths: [
+      new google.maps.LatLng(19.3342,-99.1972),
+      new google.maps.LatLng(19.3116,-99.1982),
+      new google.maps.LatLng(19.3070,-99.1834),
+      new google.maps.LatLng(19.3125,-99.1726),
+      new google.maps.LatLng(19.3362,-99.1800)
+          ]
+  	});
+  
   var myLatLng = {
     lat : 19.3302 ,
     lng : -99.1892
@@ -39,11 +57,77 @@ function initMap() {
   });
 	
   marker.addListener('dragend',function(){
-    var latitud;
-    var longitud;
-    latitud = marker.getPosition().lat();
-    longitud = marker.getPosition().lng();
-    $("#latitud").val(latitud.toFixed(6));
-    $("#longitud").val(longitud.toFixed(6));
+    if(google.maps.geometry.poly.containsLocation(
+      new google.maps.LatLng(marker.getPosition().lat(), 
+      marker.getPosition().lng()), CU)){
+    
+      var latitud;
+      var longitud;
+      latitud = marker.getPosition().lat();
+      longitud = marker.getPosition().lng();
+	  $("#latitud").val(latitud.toFixed(6));
+      $("#longitud").val(longitud.toFixed(6));
+      var datos = {"x": latitud, "y":longitud};
+      $("#checkRutas").empty();
+      verificarEstacionRuta("/RestEstacion/verificarRuta",datos);
+    }else{
+      $("#modalAgregarEstacion button#modalEnviar").prop("disabled",true);
+      var container = $("#checkRutas");
+      $(container).empty();
+      $('<div />',{class: 'alert alert-danger sinRutas centrar-texto',
+        role:"alert"}).appendTo(container);
+      $(".sinRutas").append("<p>La estación se encuentra fuera de Ciudad Universitaria.</p>");
+    }
   });
 }
+
+function verificarEstacionRuta(url,datos){
+  $.ajax({
+    url:'/movilidad-unam-web'+url,
+    type:"POST",
+    contentType : "application/json",
+    data: JSON.stringify(datos),
+    dataType: "json",
+    success:function(data){
+      var longitud = data.length;
+      var container = $("#checkRutas");
+      if (longitud > 0) {
+        $("#checkRutas").append("<p>Seleccione las rutas a la que sera asociada " +
+        		"la estaci&oacute;n.</p>");
+        $('<div />',{class: 'row renglon'}).appendTo(container);
+
+        for (var i = 0; i < longitud; i++) {
+          $('<div />',{class: 'col-xs-12 col-sm-6',id:'column_'+data[i].rutaId}).appendTo(
+             	  $('div.renglon'));
+          $('<div />',{class: 'form-check',id:'check_'+data[i].rutaId}).appendTo(
+                  $('div#column_'+data[i].rutaId));
+          $('<input />',{'data-id':data[i].rutaId,type:'checkbox',
+        	  class:'form-check-input checkEstacionRuta',name:'rutas[]'}).appendTo(
+                  $("div#check_"+data[i].rutaId));
+          $('<label />',{text:data[i].rutaNombre,class:'form-check-label'}).appendTo(
+                  $("div#check_"+data[i].rutaId));
+        }
+      }else{
+        $(container).empty();
+        $('<div />',{class: 'alert alert-danger sinRutas centrar-texto',
+                     role:"alert"}).appendTo(container);
+        $(".sinRutas").append("<p>No se han encontrados rutas cercanas al punto.</p>");
+      }
+    },
+    error:function(jqXHR, textStatus, errorThrown){
+      console.log("Ajax mal ");	
+    }
+  });
+}
+
+function relacionRutaEstacion(checkSeleccionados){	
+  var rutaIds = [];
+  for (var i = 0; i < checkSeleccionados.length; i++) {
+    var id = $(checkSeleccionados[i]).attr("data-id");
+    rutaIds.push(id);
+  }
+  return rutaIds;
+}
+
+
+

--- a/movilidad-unam-web/src/main/webapp/WEB-INF/views/jsp/estacion/agregar.jsp
+++ b/movilidad-unam-web/src/main/webapp/WEB-INF/views/jsp/estacion/agregar.jsp
@@ -20,6 +20,7 @@
       <input type="text" name="longitud" class="form-control" id="longitud" placeholder="Longitud">
     </div>
   </div>
+  <div id="checkRutas" ></div>
 </form>
 
 <div id="map"></div>


### PR DESCRIPTION
De acuerdo a lo que platicamos en la ultima reunión se realizan las siguientes validaciones al guardar una estación:
1. Al mover el marcador obtiene las rutas cercanas a esa estación, si no hay rutas cercanas al marcador se le indica al usuario y no se permite el guardado.
2. Se debe de seleccionar al menos una ruta para la estación, si no se ha seleccionado alguna no se permite el guardado y se le informa al usuario.
3.Se verifica que el punto (marcador) colocado en el mapa ente dentro de CU.